### PR TITLE
fix windows installation

### DIFF
--- a/src/pyedfread/__init__.py
+++ b/src/pyedfread/__init__.py
@@ -1,4 +1,17 @@
 """Read eye-tracking information from EyeLink EDF files."""
 
+
+import sys
+if sys.platform.startswith("win32"):
+    import os
+    import platform
+    srr_basedir = r"C:\Program Files (x86)\SR Research\EyeLink"
+    if platform.architecture()[0] == "64bit":
+        arch_dir = 'x64'
+    else:
+        arch_dir = ''
+    # due to a change in python 3.8, the searchpath is not automatically added anymore
+    os.add_dll_directory(os.path.join(srr_basedir, 'libs', arch_dir))
+           
 from pyedfread.parse import read_edf
 from pyedfread.edf_read import read_preamble, read_messages, read_calibration


### PR DESCRIPTION
this addresses the windows portion of #32.

Instead of automatically adding the dll to the searchpart, we now have to do it manually. I couldnt figure out how to move it during installation, which would be ideal - there is probably a smarter way to do it.

Concurrently I updated to setuptools.