### PR TITLE
fix #37, end of samples was filled with wrongly initialized values

### DIFF
--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -333,4 +333,7 @@ def parse_edf(
                 data, sample_type, trial, current_event, event_accumulator
             )
     free(buf)
+    # num_elements contained number of combined samples, messages, and events. This truncates
+    # to only number of samples read (cnt).
+    samples = samples[:cnt, :];
     return samples, event_accumulator, message_accumulator

--- a/tests/nppBackup/test_read_edf.py.2025-04-15_115210.bak
+++ b/tests/nppBackup/test_read_edf.py.2025-04-15_115210.bak
@@ -18,12 +18,6 @@ def edf_data():
     data = {"samples": samples, "events": events, "messages": messages}
     return data
 
-def test_samples(edf_data):
-    samples = edf_data["samples"]
-
-    # test for #37
-    assert samples[samples.time.diff()!=1].shape == (1,40)
-
 
 def test_messages(edf_data):
     """Compare messages to known values."""

--- a/tests/nppBackup/test_read_edf.py.2025-04-15_115222.bak
+++ b/tests/nppBackup/test_read_edf.py.2025-04-15_115222.bak
@@ -21,7 +21,6 @@ def edf_data():
 def test_samples(edf_data):
     samples = edf_data["samples"]
 
-    # test for #37
     assert samples[samples.time.diff()!=1].shape == (1,40)
 
 


### PR DESCRIPTION
Fixed by @flyingfalling 

Test by @behinger 

closes #38 